### PR TITLE
Add zero padded versions of the month and day in the BaseEntry class.

### DIFF
--- a/acrylamid/base.py
+++ b/acrylamid/base.py
@@ -68,7 +68,7 @@ class BaseEntry(object):
         return self.date.month
 
     @property
-    def zero_padded_month(self):
+    def zmonth(self):
         return '%02d' % self.month
 
     @property
@@ -76,7 +76,7 @@ class BaseEntry(object):
         return self.date.day
 
     @property
-    def zero_padded_day(self):
+    def zday(self):
         return '%02d' % self.day
 
     @property

--- a/docs/templating.rst
+++ b/docs/templating.rst
@@ -78,14 +78,14 @@ entry
 :month:
     entry's month (Integer)
 
-:zero_padded_month:
+:zmonth:
     zero padded month number of the entry, e.g. "05" for May and "11"
     for November (String)
 
 :day:
     entry's day (Integer)
 
-:zero_padded_day:
+:zday:
     zero padded day number of the entry, e.g. "04", "17" (String)
 
 :filters:


### PR DESCRIPTION
By adding these properties, you can configure URLs like this:
    /:year/:zero_padded_month/:zero_padded_day/:slug/
to get:
    /2012/06/01/example
