### PR TITLE
Fix template caching for Mako

### DIFF
--- a/acrylamid/core.py
+++ b/acrylamid/core.py
@@ -104,9 +104,13 @@ class cache(object):
 
     @classmethod
     def _list_dir(self):
-        """return a list of valid cache filenames"""
+        """return a list of valid cache filenames
+
+        jinja2 suffixes cached templates with .cache
+        for mako, we prefix cached templates with cache_
+        """
         return [join(self.cache_dir, fn) for fn in os.listdir(self.cache_dir)
-                if not fn.endswith('.cache')]
+                if not (fn.endswith('.cache') or fn.startswith('cache_'))]
 
     @classmethod
     def init(self, cache_dir=None, mode=0600):

--- a/acrylamid/templates/mako.py
+++ b/acrylamid/templates/mako.py
@@ -16,6 +16,11 @@ class Environment(AbstractEnvironment):
     def init(self, layoutdir, cachedir):
         self.mako = TemplateLookup(directories=[layoutdir],
             module_directory=cachedir,
+            # similar to mako.template.Template.__init__ but with
+            # leading cache_ for the acrylamid cache
+            modulename_callable=lambda filename, uri:\
+                os.path.join(os.path.abspath(cachedir), 'cache_' +
+                    os.path.normpath(uri.lstrip('/')) + '.py'),
             input_encoding='utf-8')
         self.filters = {}
         return


### PR DESCRIPTION
Acrylamids Cache would delete all files that do not explicitly end with
.cache, which is the default for jinja2.
For Mako we hack the modulename of templates to prefix them with cache_
so that we can exclude those files when shutting down the Cache.
