### PR TITLE
Monitor for changes in conf.py

### DIFF
--- a/acrylamid/__init__.py
+++ b/acrylamid/__init__.py
@@ -230,7 +230,7 @@ def Acryl():
         log.info(' * Running on http://127.0.0.1:%i/' % options.port)
 
         try:
-            commands.autocompile(conf, env, **options.__dict__)
+            commands.autocompile(ws, conf, env, **options.__dict__)
         except (SystemExit, KeyboardInterrupt, Exception) as e:
             ws.kill_received = True
             log.error(e.args[0])

--- a/acrylamid/lib/httpd.py
+++ b/acrylamid/lib/httpd.py
@@ -75,3 +75,8 @@ class Webserver(Thread):
     def run(self):
         self.httpd.serve_forever()
         self.join(1)
+
+    def shutdown(self):
+        """"Sets kill_recieved and closes the server socket."""
+        self.kill_received = True
+        self.httpd.socket.close()


### PR DESCRIPTION
Restarts the whole acrylamid process, if necessary to re-read the
`conf.py`.

Closes Issue #47.
