### PR TITLE
Add missing requirement: Mako.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 version = re.search("__version__ = '([^']+)'",
                     open('acrylamid/__init__.py').read()).group(1)
 
-requires = ['Jinja2>=2.4', 'Markdown>=2.0.1']
+requires = ['Jinja2>=2.4', 'Markdown>=2.0.1', 'Mako']
 kw = {}
 
 if sys.version_info[0] >= 3:


### PR DESCRIPTION
Commit 373f572 adds "from mako.<module> import <stuff>" in the mako
templating filter. But if Mako is not installed, acrylamid issues a
warning about an ImportError.

This commit adds Mako as a requirement in setup.py.
