### PR TITLE
Fix incorrect use of .rstrip method in the sitemap

### DIFF
--- a/acrylamid/helpers.py
+++ b/acrylamid/helpers.py
@@ -32,7 +32,7 @@ except ImportError:
     unidecode = None  # NOQA
 
 __all__ = ['memoize', 'union', 'mkfile', 'md5', 'expand', 'joinurl',
-           'safeslug', 'paginate', 'escape', 'system', 'event']
+           'safeslug', 'paginate', 'escape', 'system', 'event', 'rchop']
 
 _slug_re = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.:]+')
 
@@ -372,3 +372,14 @@ class event:
     def remove(self, path):
         """:param path: path"""
         log.info("remove  %s", path)
+
+
+def rchop(original_string, substring):
+    """Return the given string after chopping of a substring from the end.
+
+    :param original_string: the original string
+    :param substring: the substring to chop from the end
+    """
+    if original_string.endswith(substring):
+        return original_string[:-len(substring)]
+    return original_string

--- a/acrylamid/views/sitemap.py
+++ b/acrylamid/views/sitemap.py
@@ -10,7 +10,7 @@ from time import strftime, gmtime
 from os.path import join, getmtime, exists
 
 from acrylamid.views import View
-from acrylamid.helpers import event, joinurl
+from acrylamid.helpers import event, joinurl, rchop
 
 
 class Map(object):
@@ -100,9 +100,10 @@ class Sitemap(View):
 
             url = join(self.conf['www_root'], fname.replace(self.conf['output_dir'], ''))
 
+            clean_url = rchop(url, 'index.html')
             if self.isfullentry(url):
-                sm.add(url.rstrip('index.html'), getmtime(fname), priority=1.0)
+                sm.add(clean_url, getmtime(fname), priority=1.0)
             else:
-                sm.add(url.rstrip('index.html'), getmtime(fname), changefreq='weekly')
+                sm.add(clean_url, getmtime(fname), changefreq='weekly')
 
         yield sm.read(), path


### PR DESCRIPTION
Using the .rstrip method all combinations of 'index.html' were stripped so e.g. /atom.xml became /ato.
