### PR TITLE
Allow to specify the slug of an entry to the metadata.

### DIFF
--- a/acrylamid/readers.py
+++ b/acrylamid/readers.py
@@ -196,7 +196,10 @@ class BaseEntry(object):
     @property
     def slug(self):
         """ascii safe entry title"""
-        return safeslug(self.title)
+        slug = self.props.get('slug', None)
+        if not slug:
+            slug = safeslug(self.title)
+        return slug
 
     @cached_property
     def permalink(self):


### PR DESCRIPTION
By allowing authors to add the slug they want to use, it is a lot
easier to migrate existing sites (where the slug might nog match the
title).
