### PR TITLE
Fix the day and month properties on entries

### DIFF
--- a/acrylamid/readers.py
+++ b/acrylamid/readers.py
@@ -217,6 +217,7 @@ class FileReader(Reader):
 
     def __repr__(self):
         return "<FileReader f'%s'>" % self.filename
+
     @property
     def extension(self):
         """Filename's extension without leading dot"""


### PR DESCRIPTION
The property was calling itself, which resulted in:

```
...
  File "/home/mark/projects/virtualenvs/vlent.nl/src/acrylamid/acrylamid/readers.py", line 313, in day
    return '%02d' % self.day
  File "/home/mark/projects/virtualenvs/vlent.nl/src/acrylamid/acrylamid/readers.py", line 313, in day
    return '%02d' % self.day
RuntimeError: maximum recursion depth exceeded while calling a Python object
```
