### PR TITLE
Add new setting CONTENT_EXTENSION for creating new entries

### DIFF
--- a/acrylamid/commands.py
+++ b/acrylamid/commands.py
@@ -263,7 +263,8 @@ def new(conf, env, title, prompt=True):
     # we need the actual defaults values
     initialize(conf, env)
 
-    fd, tmp = tempfile.mkstemp(suffix=conf['content_extension'], dir='.cache/')
+    fd, tmp = tempfile.mkstemp(suffix=conf.get('content_extension', '.txt'),
+                               dir='.cache/')
     editor = os.getenv('VISUAL') if os.getenv('VISUAL') else os.getenv('EDITOR')
 
     if not title:
@@ -284,7 +285,7 @@ def new(conf, env, title, prompt=True):
     except OSError:
         pass
 
-    filepath = p + conf['content_extension']
+    filepath = p + conf.get('content_extension', '.txt')
     if isfile(filepath):
         raise AcrylamidException('Entry already exists %r' % filepath)
     shutil.move(tmp, filepath)

--- a/docs/conf.py.rst
+++ b/docs/conf.py.rst
@@ -78,6 +78,8 @@ Variable name (default value)                       Description
 `OUTPUT_IGNORE` (|ignored|)                         A list of filename/directory-patterns which
                                                     Acrylamid should ignore.
 `CONTENT_DIR` (``content/``)                        Directory where you write your posts to.
+`CONTENT_EXTENSION` (``.txt``)                      Filename extension used for
+                                                    creating new entries.
 `CONTENT_IGNORE` (|ignored|)                        Same as ``OUTPUT_IGNORE`` but for ``CONTENT_DIR``.
 `THEME` (``layouts/``)                              Directory where you place your jinja2 templates.
 `THEME_IGNORE` (|ignored|)                          Same as ``OUTPUT_IGNORE`` but for ``THEME``.


### PR DESCRIPTION
Add new setting CONTENT_EXTENSION with default value '.txt'
for creating new entries so that the given extension will be
used and adapt command `new` accordingly.
