### PR TITLE
fixes copy statics bug

### DIFF
--- a/acrylamid/assets.py
+++ b/acrylamid/assets.py
@@ -162,14 +162,17 @@ def compile(conf, env):
     ))
 
     other = [(prefix, filelist(prefix, conf['static_ignore'])) for prefix in conf['static']]
-    other = [((relpath(path, prefix), prefix) for path in generator)
-        for prefix, generator in other]
+    if len(other):
+        other_tmp = []
+        for prefix, generator in other:
+            other_tmp += [(relpath(path, prefix), prefix) for path in generator]
+        other = other_tmp
 
     files = ((path, conf['theme']) for path in filelist(conf['theme'], conf['theme_ignore']))
     files = ((relpath(path, prefix), prefix) for path, prefix in files)
     files = ((path, prefix) for path, prefix in files if path not in env.engine.templates)
 
-    for path, directory in chain(files, chain(*other)):
+    for path, directory in chain(files, other):
 
         # initialize writer for extension if not already there
         _, ext = splitext(path)


### PR DESCRIPTION
on compiling with several static directories only the last one got applied.
collecting the files dosen't work that way
down here a little example

``` python
other = [('a', xrange(1, 11)), ('b', xrange(11, 21))]
print other
other = [((item, prefix) for item in generator)
    for prefix, generator in other]
prefix = 'oh noes!'
print other
for x in other:
    print list(x)
```
