### PR TITLE
Prevent acrylamid from choking on plain Pandoc files

### DIFF
--- a/acrylamid/readers.py
+++ b/acrylamid/readers.py
@@ -681,11 +681,10 @@ def pandocstyle(fileobj):
 	if len(meta) > 3:
 			raise AcrylamidException("%r has too many items to be a valid title block."  % fileobj.name)
 	
-	print meta
-	
 	if len(meta['title']) > 1:
 		meta['title'] = ' '.join(meta['title'])
 	
+	print len(meta['author'])
 	meta['author'] = [item for sublist in meta['author'] for item in sublist]
 
 	for key, values in meta.iteritems():


### PR DESCRIPTION
Properly formatted Pandoc files have Title, Author(s) and Date in the so-called 'Title Block', but this information is ignored by acrylamid and it claims that there is no title.  Ideally acrylamid would extract what it could from the Title Block and only fail if sufficient information isn't found there.  

A (very) ugly and preliminary (but workable) fix is provided here.  Apologies if this isn't the right way to go about this, but I am pretty new to Python and to Git.

Thoughts?
