### PR TITLE
fix TypeError from `acrylamid view` in Python 3

### DIFF
--- a/acrylamid/lib/httpd.py
+++ b/acrylamid/lib/httpd.py
@@ -44,7 +44,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
         return joinurl(os.getcwd(), self.www_root, path[len(os.getcwd()):])
 
     def end_headers(self):
-        self.wfile.write('Cache-Control: max-age=0, must-revalidate\r\n')
+        self.wfile.write(b'Cache-Control: max-age=0, must-revalidate\r\n')
         SimpleHTTPRequestHandler.end_headers(self)
 
 


### PR DESCRIPTION
When a browser asks acrylamid's server for something that doesn't exist in
output (e.g.: favicon.ico), an IOError bubbles up from http.server.
In the course of handling this, acrylamid.lib.httpd:end_headers (line 47) tries
to write a Cache-Control header. However, the string arg is of type str,
yielding:

```
TypeError: 'str' does not support the buffer interface
```

that's really because write() is expecting a bytestring, like b''.
So, this change just adds that b prefix before the string literal.
