### PR TITLE
fix Article archive considers non-root paths.

### DIFF
--- a/acrylamid/defaults/html5/jinja2/articles.html
+++ b/acrylamid/defaults/html5/jinja2/articles.html
@@ -19,7 +19,7 @@
             {% for entry in month.items %}
                 <tr>
                     <th>{{ entry.date.day }}</th>
-                    <td><a href="{{ entry.permalink }}">{{ entry.title | e }}</a></td>
+                    <td><a href="{{ env.path + entry.permalink }}">{{ entry.title | e }}</a></td>
                 </tr>
             {% endfor %}
         {% endfor %}

--- a/acrylamid/defaults/html5/mako/articles.html
+++ b/acrylamid/defaults/html5/mako/articles.html
@@ -19,7 +19,7 @@
             % for entry in month.items:
                 <tr>
                     <th>${ entry.date.day }</th>
-                    <td><a href="${ entry.permalink }" rel="bookmark canonical">${ entry.title }</a></td>
+                    <td><a href="${ env.path + entry.permalink }" rel="bookmark canonical">${ entry.title }</a></td>
                 </tr>
             % endfor
         % endfor

--- a/acrylamid/defaults/shadowplay/jinja2/articles.html
+++ b/acrylamid/defaults/shadowplay/jinja2/articles.html
@@ -18,7 +18,7 @@
     </tr>
     {% for entry in months %}
       <tr><th>{{ entry.date.day }}</th>
-          <td><a href="{{ entry.permalink }}" rel="bookmark canonical">{{ entry.title | e }}</a></td>
+          <td><a href="{{ env.path + entry.permalink }}" rel="bookmark canonical">{{ entry.title | e }}</a></td>
       </tr>
     {% endfor %}
   {% endfor %}


### PR DESCRIPTION
Link from archive to articles which may not be on the root folder.
