### PR TITLE
RSS and TZ

### DIFF
--- a/acrylamid/views/feeds.py
+++ b/acrylamid/views/feeds.py
@@ -10,8 +10,13 @@ from acrylamid.utils import HashableList, total_seconds
 from acrylamid.views import View, tag
 from acrylamid.helpers import joinurl, event, expand, union
 from acrylamid.readers import Timezone
+from wsgiref.handlers import format_date_time
 
-epoch = datetime.utcfromtimestamp(0).replace(tzinfo=Timezone(0))
+
+def normdate(dt):
+    epoch = datetime.utcfromtimestamp(0)
+    if dt.tzinfo: epoch = epoch.replace(tzinfo=Timezone(0))
+    return unicode(format_date_time(total_seconds(dt-epoch)))
 
 
 def utc(dt, fmt='%Y-%m-%dT%H:%M:%SZ'):
@@ -105,12 +110,8 @@ class RSS(Feed):
     def init(self, conf, env, num_entries=25):
         super(RSS, self).init(conf, env)
 
-        from wsgiref.handlers import format_date_time
-        from time import mktime
-
         self.num_entries = num_entries
-        env.engine.register(
-            'rfc822', lambda dt: unicode(format_date_time(total_seconds(dt - epoch))))
+        env.engine.register('rfc822',normdate)
         self.type = 'rss'
 
 
@@ -128,10 +129,6 @@ class RssPerTag(FeedPerTag):
     def init(self, conf, env, num_entries=25):
         super(RssPerTag, self).init(conf, env)
 
-        from wsgiref.handlers import format_date_time
-        from time import mktime
-
         self.num_entries = num_entries
-        env.engine.register(
-            'rfc822', lambda dt: unicode(format_date_time(total_seconds(dt - epoch))))
+        env.engine.register('rfc822',normdate)
         self.type = 'rss'


### PR DESCRIPTION
Hi again,

I was having trouble generating an RSS feed, something to do with subtracting datestamps with and without timezone info: in feeds.py, epoch always has one but for dt it seems to dpend on what is specified as the 'date' field.

The attached patch attaches TZ info to epoch only if there is one in td.

What do you think of it?
