### PR TITLE
Doubleslash

### DIFF
--- a/acrylamid/commands.py
+++ b/acrylamid/commands.py
@@ -13,7 +13,7 @@ from urlparse import urlsplit
 from datetime import datetime
 from itertools import chain
 from collections import defaultdict
-from os.path import getmtime
+from os.path import getmtime, normpath
 
 from distutils.version import LooseVersion
 
@@ -97,7 +97,7 @@ def initialize(conf, env):
     env['path'] = env['path'].rstrip('/')
 
     if env['path']:
-        conf['output_dir'] = conf['output_dir'] + env['path']
+        conf['output_dir'] = normpath(conf['output_dir'] + env['path'])
 
     # check if encoding is available
     try:

--- a/acrylamid/views/sitemap.py
+++ b/acrylamid/views/sitemap.py
@@ -85,7 +85,7 @@ class Sitemap(View):
             if ns == 'draft':
                 continue
 
-            url = conf['www_root'] + '/' + fname.replace(conf['output_dir'], '')
+            url = conf['www_root'] + fname.replace(conf['output_dir'], '')
             priority, changefreq = self.scores.get(ns, (0.5, 'weekly'))
             sm.add(rchop(url, 'index.html'), getmtime(fname), changefreq, priority)
 


### PR DESCRIPTION
Hi, me again ...

The variable conf['output_path'] ended up with a double-slash, making the string.replace in sitemap.py do nothing, and generating an invalid sitemap as a result. Use normpath to fix that.

Maybe os.path.join everywhere instead of a+"/"+b would lead to simpler code? Hard to follow all the added trailing slashes and stripped again trailing slashes sometimes ...
