### PR TITLE
Import task fixes

### DIFF
--- a/acrylamid/tasks/imprt.py
+++ b/acrylamid/tasks/imprt.py
@@ -377,7 +377,8 @@ def build(conf, env, defaults, items, options):
 
         if options.keep:
             m = urlsplit(item['link'])
-            item['permalink'] = m.path if m.path != '/' else None
+            if m.path != '/':
+                item['permalink'] = m.path
 
         item['content'], item['filter'] = convert(item.get('content', ''),
             options.fmt, options.pandoc)


### PR DESCRIPTION
I'm trying to migrate my existing Wordpress blog and have encountered a few issues which I'm addressing here.
- Raw HTML such as the `<!--more-->` comment and `<table>` tags were not passed through in the Pandoc conversion process into the Markdown format. This is fixed by passing `--parse-raw` to pandoc, although I'm unsure if there'll be any side effects for other formats
- The `filter` header is _always_ written out to the Markdown front matter for _all_ imported entries. This causes the `markdown+codehilite+...` filter specified in global `conf.py` to be ignored. I would think it makes sense to **not** specify the `filter` for each entry since you would likely be converting it into a common format used by all entries anyway.
- The `draft` header is not written out to the front matter, causing the draft status to be lost.
- There's a bug that causes an Exception when `--keep-links` is specified during import. In some cases, the Wordpress permalink may be `http://blog.wordpress.com/?p=100` which causes a `None` to be assigned to the entry's permalink (since `m.path == '/'`). This in turn causes the Entry to **not** assign a permalink and hence retain `permalink = None` and `dirname(entry.permalink)[1:]` to throw an Exception. The correct fix in this case is to not assign `entry['permalink']` at all and let the Entry create a permalink based on the safeslug from the entry title.
