### PR TITLE
Fix importing of "page" entries

### DIFF
--- a/acrylamid/tasks/imprt.py
+++ b/acrylamid/tasks/imprt.py
@@ -255,6 +255,9 @@ def wordpress(xml):
         # attachment, nav_menu_item, page, post
         entry['type'] = item.find('%spost_type' % wpns).text
 
+        if entry['type'] == 'post':
+            entry['type'] = 'entry'
+
         if item.find('%sstatus' % wpns).text != 'publish':
             entry['draft'] = True
 
@@ -279,7 +282,7 @@ def wordpress(xml):
         if tree.find('channel/%swxr_version' % wpns) is None:
             continue
         entries = list(map(generate, tree.findall('channel/item')))
-        return defaults, [entry for entry in entries if entry['type'] in ('page', 'post')]
+        return defaults, [entry for entry in entries if entry['type'] in ('page', 'entry')]
 
 
 def fetch(url, auth=None):
@@ -346,6 +349,8 @@ def build(conf, env, defaults, items, options):
                 f.write(u'tags: [%s]\n' % ', '.join(item['tags']))
             if 'permalink' in item:
                 f.write(u'permalink: %s\n' % item['permalink'])
+            if item.get('type', 'entry') != 'entry':
+                f.write(u'type: %s\n' % item['type'])
             for arg in options.args:
                 f.write(arg.strip() + u'\n')
             f.write(u'---\n\n')


### PR DESCRIPTION
The `type` header was not written out in the YAML front matter, thus causing imported "page" entries to be incorrectly recognized as normal "entry"s.

This fix writes the `type` header only if the type is not "entry".
