### PR TITLE
Escape quotes in HTML attributes

### DIFF
--- a/acrylamid/lib/html.py
+++ b/acrylamid/lib/html.py
@@ -43,7 +43,7 @@ def format(attrs):
         if value is None:
             res.append(key)
         else:
-            res.append('%s="%s"' % (key, escape(value)))
+            res.append('%s="%s"' % (key, escape(value, quote=True)))
     return ' '.join(res)
 
 


### PR DESCRIPTION
Quotes in HTML attributes are not quoted, thereby causing the HTMLParser to ignore the remaining part of the document. This bug was found due to a [Python-Markdown parsing bug I've filed here](https://github.com/waylan/Python-Markdown/pull/275).

The bug only happens when more than one filter that uses HTMLParser is chained. The input HTML is `<img ... title="&quot;title" />` and after one round of parsing it becomes `<img ... title=""title" />` and this input to the next filter will result in (silent) truncation due to invalid HTML.
