### PR TITLE
Discover 'views' from the local directory, just like 'filters' & 'tasks'

### DIFF
--- a/acrylamid/views/__init__.py
+++ b/acrylamid/views/__init__.py
@@ -89,6 +89,7 @@ def initialize(directories, conf, env):
             urlmap.append((rule, item))
 
     directories += [os.path.dirname(__file__)]
+    directories += ['views/']
     helpers.discover(directories, partial(index_views, conf, env, urlmap),
         lambda path: path.rpartition('.')[0] != __file__.rpartition('.')[0])
 


### PR DESCRIPTION
I'm not sure if this was a bug, but views are not loaded from the local directory. This patch adds the current `views` directory to be scanned.
