### PR TITLE
FIX: Don't force index.html at the end of Articles view

### DIFF
--- a/acrylamid/views/articles.py
+++ b/acrylamid/views/articles.py
@@ -44,7 +44,7 @@ class Articles(View):
         entrylist = data['entrylist']
 
         tt = env.engine.fromfile(self.template)
-        path = joinurl(conf['output_dir'], self.path, 'index.html')
+        path = joinurl(conf['output_dir'], self.path)
 
         if exists(path) and not (conf.modified or env.modified or tt.modified):
             event.skip('article', path)


### PR DESCRIPTION
User might want articles view to show up not as a directory, but as articles.html In this case, this is pointless to enforce index.html at the end of the path.
