### PR TITLE
Added an "sdescription" property to return only the entry description

### DIFF
--- a/acrylamid/readers.py
+++ b/acrylamid/readers.py
@@ -470,6 +470,10 @@ class MetadataMixin(object):
         return True if self.props.get('draft', False) else False
 
     @property
+    def sdescription(self):
+        return self.props.get('description', '')
+
+    @property
     def description(self):
         """first 50 characters from the source"""
         try:


### PR DESCRIPTION
The current behavior of the `description` property automatically extracts the first 50 characters of the source, which may contain Markdown code instead of text. This also prevents the caller from distinguishing whether a description was explicitly set in the front matter.

Instead, `sdescription` returns an empty string if a description was not set, and allows the summary to be performed inside the template like so:

```
 <meta name="description" content="{{ content.sdescription or content.entry|striptags|summarize }}">
```

which guarantees proper text since `content.entry` is already processed HTML.

For lack of a better name, `sdescription` was chosen for "string description" because there was already `imonth`, `iday`, etc which I believe represents "integer _something_".
