### PR TITLE
fix #200: Mention Isso as an alternate comment system.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,10 +119,14 @@ blogging features
 what is missing
 ~~~~~~~~~~~~~~~
 
-- No comments. You have to use Disqus_ or `this approach`_.
+- No comments. You have to either use a service such as Disqus_,
+  a software like Isso_, or a custom work like `this approach`_ or
+  `that other one`_.
 
 .. _Disqus: http://disqus.com/
+.. _Isso: http://posativ.org/isso/
 .. _this approach: http://hezmatt.org/~mpalmer/blog/2011/07/19/static-comments-in-jekyll.html
+.. _that other one: https://github.com/getpelican/pelican-plugins/tree/master/pelican_comment_system
 
 Quickstart
 ----------


### PR DESCRIPTION
This small change to _acrylamid_ doc index page should fix [issue no. 200](https://github.com/posativ/acrylamid/issues/200), although I'm not confident in its english phrasing.

By the way, I also mention an other alternative for comment system, used by a Pelican plugin, which use mailto: link to send formatted comments for reviewing (inserting them in doc. remains to the blogger). This has the advantage to not require any additional piece of software on the server side.
