### PR TITLE
doc: Fix typos in description of Page view.

### DIFF
--- a/docs/views/single.rst
+++ b/docs/views/single.rst
@@ -30,11 +30,11 @@ template.
 Page
 ----
 
-Creates a static page. To enable Entry view, add this to your :doc:`conf.py`:
+Creates a static page. To enable Page view, add this to your :doc:`conf.py`:
 
 .. code-block:: python
 
-    '/:year/:slug/': {
+    '/:slug/': {
         'view': 'page',
         'template': 'main.html'  # default, includes entry.html
     }


### PR DESCRIPTION
This small change should fix some typos in description of Page view: it seems that its content was copied from above section about Entry view. The main change involves in rewriting URL template, removing the `:year` prefix, which could not make full sense for static pages.

Feel free to include none, part or all of this ;-) 
