### PR TITLE
doc: Fix native reStructuredText example for tags, surrounding them with brackets

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -153,7 +153,7 @@ reStructuredText:
     #####
 
     :type: page
-    :tags: one, two
+    :tags: [one, two]
 
     Here begins the body ...
 


### PR DESCRIPTION
Here is yet another small fix in doc, unifomizing how tags must be set in reStructuredText example entry with others (YAML, markdown).

As a side note, it could be cleaner IMHO if in native metadata style (markdown, reST) those brackets could be ignored. I tried but failed to quicly find where parsing tags occurs, to measure feasability of such a change. What do you think about ?-)
