### PR TITLE
Fix wrong except IndexError -> StopIteration

### DIFF
--- a/acrylamid/filters/__init__.py
+++ b/acrylamid/filters/__init__.py
@@ -288,7 +288,7 @@ class FilterList(list):
 
         try:
             f = next(filter(lambda x: item in x.match, self))
-        except IndexError:
+        except StopIteration:
             raise ValueError('%s is not in list' % item)
 
         return f


### PR DESCRIPTION
In `FilterList.__getitem__` where the `match` is checked a wrong exception is expected. Using an iterator and not a `list[idx]`, a `StopIteration` is what we can expect.
