### PR TITLE
Set dates in the test entries to make sure the permalink has the right year

### DIFF
--- a/acrylamid/specs/entry.py
+++ b/acrylamid/specs/entry.py
@@ -62,17 +62,17 @@ class TestEntry(attest.TestBase):
     @attest.test
     def permalink(self):
 
-        create(self.path, title='foo')
+        create(self.path, date='18.10.2013', title='foo')
         entry = Entry(self.path, conf)
 
         assert entry.permalink == '/2013/foo/'
 
-        create(self.path, title='foo', permalink='/hello/world/')
+        create(self.path, date='18.10.2013', title='foo', permalink='/hello/world/')
         entry = Entry(self.path, conf)
 
         assert entry.permalink == '/hello/world/'
 
-        create(self.path, title='foo', permalink_format='/:year/:slug/index.html')
+        create(self.path, date='18.10.2013', title='foo', permalink_format='/:year/:slug/index.html')
         entry = Entry(self.path, conf)
 
         assert entry.permalink == '/2013/foo/'


### PR DESCRIPTION
If there is no date set when creating an entry, the current year is assumed. But since the permalink contains the year, we either have to make the year dynamic in the test, or specify the date when creating the test entry. I chose the latter option.