### PR TITLE
Fix #244: If task return code does not equal zero, raise an exception.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 install:
   - pip install --use-mirrors -r test-requirements.txt
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors
-    translitcodec argparse; fi
+    translitcodec argparse markdown==2.4.1; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install --use-mirrors translitcodec; fi
   - python setup.py -q install
 script:

--- a/acrylamid/specs/compile.t
+++ b/acrylamid/specs/compile.t
@@ -148,7 +148,7 @@ Now we change the base template and should see some updates:
 
   $ acrylamid compile -Cv
   update  [?.??s] output/articles/index.html (glob)
-  update  [?.??s] output/2013/spam/index.html (glob)
+  update  [?.??s] output/????/spam/index.html (glob)
   update  [0.??s] output/2012/die-verwandlung/index.html (glob)
   update  [0.??s] output/index.html (glob)
   update  [0.??s] output/tag/die-verwandlung/index.html (glob)
@@ -168,7 +168,7 @@ If we change a filter in conf.py we should see an update:
   > fi
   $ acrylamid compile -Cv
   identical  output/articles/index.html
-  identical  output/2013/spam/index.html
+  identical  output/????/spam/index.html (glob)
   update  [?.??s] output/2012/die-verwandlung/index.html (glob)
   update  [0.??s] output/index.html (glob)
   update  [0.??s] output/tag/die-verwandlung/index.html (glob)

--- a/acrylamid/specs/compile.t
+++ b/acrylamid/specs/compile.t
@@ -130,7 +130,7 @@ And now vice versa: we touch completely different templates:
 
   $ acrylamid compile -Cv
   skip  output/articles/index.html
-  skip  output/???/spam/index.html (glob)
+  skip  output/????/spam/index.html (glob)
   skip  output/2012/die-verwandlung/index.html
   skip  output/index.html
   skip  output/tag/die-verwandlung/index.html

--- a/acrylamid/specs/compile.t
+++ b/acrylamid/specs/compile.t
@@ -72,7 +72,7 @@ Lets try if we have really incremental rendering:
   $ acrylamid new -q Spam
   $ acrylamid compile -Cv
   update  [?.??s] output/articles/index.html (glob)
-  create  [?.??s] output/2013/spam/index.html (glob)
+  create  [?.??s] output/????/spam/index.html (glob)
   update  [0.??s] output/2012/die-verwandlung/index.html (glob)
   update  [?.??s] output/index.html (glob)
   identical  output/tag/die-verwandlung/index.html
@@ -96,7 +96,7 @@ Edit some modification timestamps.
 
   $ acrylamid compile -Cv
   identical  output/articles/index.html
-  identical  output/2013/spam/index.html
+  identical  output/????/spam/index.html (glob)
   identical  output/2012/die-verwandlung/index.html
   identical  output/index.html
   identical  output/tag/die-verwandlung/index.html
@@ -113,7 +113,7 @@ Now we touch a parent template and all inherited templates should change as, too
 
   $ acrylamid compile -Cv
   identical  output/articles/index.html
-  identical  output/2013/spam/index.html
+  identical  output/????/spam/index.html (glob)
   identical  output/2012/die-verwandlung/index.html
   identical  output/index.html
   identical  output/tag/die-verwandlung/index.html
@@ -130,7 +130,7 @@ And now vice versa: we touch completely different templates:
 
   $ acrylamid compile -Cv
   skip  output/articles/index.html
-  skip  output/2013/spam/index.html
+  skip  output/???/spam/index.html (glob)
   skip  output/2012/die-verwandlung/index.html
   skip  output/index.html
   skip  output/tag/die-verwandlung/index.html

--- a/acrylamid/specs/entry.py
+++ b/acrylamid/specs/entry.py
@@ -62,17 +62,17 @@ class TestEntry(attest.TestBase):
     @attest.test
     def permalink(self):
 
-        create(self.path, title='foo')
+        create(self.path, date='18.10.2013', title='foo')
         entry = Entry(self.path, conf)
 
         assert entry.permalink == '/2013/foo/'
 
-        create(self.path, title='foo', permalink='/hello/world/')
+        create(self.path, date='18.10.2013', title='foo', permalink='/hello/world/')
         entry = Entry(self.path, conf)
 
         assert entry.permalink == '/hello/world/'
 
-        create(self.path, title='foo', permalink_format='/:year/:slug/index.html')
+        create(self.path, date='18.10.2013', title='foo', permalink_format='/:year/:slug/index.html')
         entry = Entry(self.path, conf)
 
         assert entry.permalink == '/2013/foo/'

--- a/acrylamid/tasks/deploy.py
+++ b/acrylamid/tasks/deploy.py
@@ -56,3 +56,6 @@ def run(conf, env, options):
         if output != '':
             sys.stdout.write(output)
             sys.stdout.flush()
+
+    if p.returncode:
+        raise AcrylamidException('tasks %r exited with return code %r' % (task, p.returncode))


### PR DESCRIPTION
With this change, the exit code of the deploy command is 1 instead of 0 when the deploy fails.