### PR TITLE
Fixed bug https://github.com/posativ/acrylamid/issues/251

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ MANIFEST
 /build/
 /acrylamid.egg-info/
 /src/
+dist/

--- a/acrylamid/views/entry.py
+++ b/acrylamid/views/entry.py
@@ -41,12 +41,18 @@ class Base(metaclass(abc.ABCMeta, View)):
         pathes, entrylist = set(), data[self.type]
         unmodified = not env.modified and not conf.modified
 
+        # fixes https://github.com/posativ/acrylamid/issues/251
         for i, entry in enumerate(entrylist):
 
             if entry.hasproperty('permalink'):
                 path = joinurl(conf['output_dir'], entry.permalink)
             else:
                 path = joinurl(conf['output_dir'], expand(self.path, entry))
+                entry.permalink = path.replace(conf.output_dir, '/')
+
+        for i, entry in enumerate(entrylist):
+
+            path = joinurl(conf['output_dir'], entry.permalink)
 
             if isfile(path) and path in pathes:
                 try:


### PR DESCRIPTION
For some reason if you had multiple types of entries (say two completely
seperate blogs (blog1 and blog2), the permalinks for _all_ blogs would get set
to either /blog1/\* or /blog2/\* (with the /blog{1,2}/:slug/ view rules).

This fixes it so the permalink for a given entry, if not already set, is
assigned correctly.

The only changes occured in acrylamid/views/entry.py.

It was basically a one-line fix.

fixes #251 
